### PR TITLE
Added an upduino31 RGB blinky example. 

### DIFF
--- a/upduino31/blinky/.gitignore
+++ b/upduino31/blinky/.gitignore
@@ -1,0 +1,8 @@
+.sconsign.dblite
+*.vcd
+*.out
+hardware.rpt
+hardware.json
+hardware.asc
+hardware.bin
+hardware.out

--- a/upduino31/blinky/apio.ini
+++ b/upduino31/blinky/apio.ini
@@ -1,0 +1,4 @@
+[env]
+board = upduino31
+top-module = main
+

--- a/upduino31/blinky/info
+++ b/upduino31/blinky/info
@@ -1,0 +1,1 @@
+Blinking the RGB LEDs using the SB_RGBA_DRV primitive.

--- a/upduino31/blinky/leds.v
+++ b/upduino31/blinky/leds.v
@@ -1,0 +1,53 @@
+// More info about the primitve led control block SB_RGBA_DRV:
+// https://github.com/tinyvision-ai-inc/UPduino-v3.0/blob/master/RTL/blink_led/rgb_blink.v
+// https://blog.idorobots.org/entries/upduino-fpga-tutorial.html
+
+module leds (
+    input clk,
+    input red_en,
+    input green_en,
+    input blue_en,
+    output wire [2:0] leds_out  // [0]=red, [1]=green, [2]=blue
+);
+
+  // Intensity multiplier for all three channels.
+  localparam integer IntensityAll = 2;
+
+  // Intensity controls in the range [0, 512].
+  localparam integer IntensityRed = 4 * IntensityAll;
+  localparam integer IntensityGreen = 2 * IntensityAll;
+  localparam integer IntensityBlue = 24 * IntensityAll;
+
+  // Frequency divider generate the PWM counter.
+  reg  [15:0] divider;
+
+  // 9 bits PWM counter.
+  wire [ 8:0] pwm_counter = divider[15:7];
+
+  wire        pwm_red = pwm_counter < IntensityRed;
+  wire        pwm_green = pwm_counter < IntensityGreen;
+  wire        pwm_blue = pwm_counter < IntensityBlue;
+
+  // Behavior.
+  always @(posedge clk) begin
+    divider <= divider + 1'b1;
+  end
+
+  // Instantiate the RGB current source primitive.
+  SB_RGBA_DRV #(
+      .CURRENT_MODE("0b1"),  // "0b0" -> full current, "0b1" -> half current.
+      .RGB0_CURRENT("0b000001"),
+      .RGB1_CURRENT("0b000001"),
+      .RGB2_CURRENT("0b000001")
+  ) RGB_DRIVER (
+      .RGBLEDEN(1'b1),
+      .RGB0PWM (green_en && pwm_green),  // Green led input.
+      .RGB1PWM (blue_en & pwm_blue),     // Blue led input.
+      .RGB2PWM (red_en & pwm_red),       // Red led input.
+      .CURREN  (1'b1),
+      .RGB0    (leds_out[1]),            // Current regulated output to green led.
+      .RGB1    (leds_out[2]),            // Current regulated output to blue led.
+      .RGB2    (leds_out[0])             // Current regulated output to red led.
+  );
+
+endmodule

--- a/upduino31/blinky/main.pcf
+++ b/upduino31/blinky/main.pcf
@@ -1,0 +1,8 @@
+# Mapping of the design signals to FPGA pins.
+
+# The full Upduino3 PCF file is availble at:
+#  https://github.com/tinyvision-ai-inc/UPduino-v3.0/tree/master/RTL/common
+
+set_io leds_out[0]     41  # Red.
+set_io leds_out[1]     39  # Green.
+set_io leds_out[2]     40  # Blue.

--- a/upduino31/blinky/main.v
+++ b/upduino31/blinky/main.v
@@ -1,0 +1,30 @@
+// Generates a RGB blinking pattern. Uses the internal oscilator.
+module main (
+    // [0]=red, [1]=green, [2]=blue. See pin definitions in main.pcf
+    output [2:0] leds_out
+);
+
+  wire clk;
+
+  oscilator oscilator (.clk(clk));
+
+  // Frequency divider to generate the RGB patterns.
+  reg  [25:0] divider;
+  wire        red_en = divider[25] & divider[24];
+  wire        green_en = divider[25] & ~divider[24];
+  wire        blue_en = ~divider[25] & divider[24];
+
+  leds leds (
+      .clk(clk),
+      .red_en(red_en),
+      .green_en(green_en),
+      .blue_en(blue_en),
+      .leds_out(leds_out)
+  );
+
+  // Behavior.
+  always @(posedge clk) begin
+    divider <= divider + 1'b1;
+  end
+
+endmodule

--- a/upduino31/blinky/oscilator.v
+++ b/upduino31/blinky/oscilator.v
@@ -1,0 +1,14 @@
+// Instanciates the internal high speed oscilator. This is needed
+// only if the external Upduino oscilator is not connected to the FPGA.
+
+module oscilator (
+    output clk
+);
+
+  SB_HFOSC interal_osc (
+      .CLKHFPU(1'b1),
+      .CLKHFEN(1'b1),
+      .CLKHF  (clk)
+  );
+
+endmodule


### PR DESCRIPTION
Added an apio blinky example for the upduino31 board. The example uses the internal oscilator since the upduino31 is shipped with the external socilator disconnected and uses the RGB LED primitive to drive the LEDs since they don't have current limiting resistors.