### PR TITLE
Added an Upduino 3.1 example that demonstrates automatic testing with 'apio test'.

### DIFF
--- a/upduino31/testbench/apio.ini
+++ b/upduino31/testbench/apio.ini
@@ -1,0 +1,4 @@
+[env]
+board = upduino31
+top-module = main
+

--- a/upduino31/testbench/bcd_counter.v
+++ b/upduino31/testbench/bcd_counter.v
@@ -1,0 +1,25 @@
+// A 4 bit BCD counter with synchronous clock and carry out. 
+// It Counts up on positive edge of clk, when count_en is high.
+
+module bcd_counter (
+    input clk,
+    input reset,
+    input count_en,
+    output reg [3:0] data_out,
+    output carry
+);
+
+  // Behavior.
+  always @(posedge clk) begin
+    if (reset || data_out > 9) begin
+      // Case 1: Reset or invalid state.;
+      data_out <= 0;
+    end else if (count_en) begin
+      // Case 1: Increment, with optional overflow from 9 to 0.
+      data_out <= (data_out == 9) ? 0 : data_out + 1;
+    end
+  end
+
+  assign carry = !reset && count_en && (data_out == 9);
+
+endmodule

--- a/upduino31/testbench/info
+++ b/upduino31/testbench/info
@@ -1,0 +1,1 @@
+A testbench with an automatic testing a sequential module.

--- a/upduino31/testbench/main.pcf
+++ b/upduino31/testbench/main.pcf
@@ -1,0 +1,20 @@
+# Mapping of the design signals to FPGA pins.
+
+# The full Upduino3 PCF file is availble at:
+#  https://github.com/tinyvision-ai-inc/UPduino-v3.0/tree/master/RTL/common
+
+set_io clk          10
+set_io reset        12
+set_io count_en     21
+set_io carry        13
+
+set_io digit_1[0]   19
+set_io digit_1[1]   18 
+set_io digit_1[2]   11
+set_io digit_1[3]    9
+
+set_io digit_10[0]  44 
+set_io digit_10[1]   4
+set_io digit_10[2]   3
+set_io digit_10[3]  48
+

--- a/upduino31/testbench/main.v
+++ b/upduino31/testbench/main.v
@@ -1,0 +1,29 @@
+// Generates a RGB blinking pattern. Uses the internal oscilator.
+module main (
+  input clk,
+  input reset,
+  input count_en,
+  output [3:0] digit_1,
+  output [3:0] digit_10,
+  output carry
+);
+
+wire carry_1;
+
+bcd_counter count_1 (
+    .clk(clk),
+    .reset(reset),
+    .count_en(count_en),
+    .data_out(digit_1),
+    .carry(carry_1)
+);
+
+bcd_counter count_10 (
+    .clk(clk),
+    .reset(reset),
+    .count_en(carry_1),
+    .data_out(digit_10),
+    .carry(carry)
+);
+
+endmodule

--- a/upduino31/testbench/main_tb.gtkw
+++ b/upduino31/testbench/main_tb.gtkw
@@ -1,0 +1,58 @@
+[*]
+[*] GTKWave Analyzer v3.4.0 (w)1999-2022 BSI
+[*] Sat Mar  2 22:47:15 2024
+[*]
+[dumpfile] "main_tb.vcd"
+[dumpfile_mtime] "Sat Mar  2 22:46:12 2024"
+[dumpfile_size] 7168
+[savefile] "main_tb.gtkw"
+[timestart] 0
+[size] 1440 900
+[pos] -1 -26
+*-22.382421 3100000 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+[markername] AA
+[markername] BB
+[markername] CC
+[markername] DD
+[markername] EE
+[markername] FF
+[markername] GG
+[markername] HH
+[markername] II
+[markername] JJ
+[markername] KK
+[markername] LL
+[markername] MM
+[markername] NN
+[markername] OO
+[markername] PP
+[markername] QQ
+[markername] RR
+[markername] SS
+[markername] TT
+[markername] UU
+[markername] VV
+[markername] WW
+[markername] XX
+[markername] YY
+[markername] ZZ
+[treeopen] main_tb.
+[sst_width] 253
+[signals_width] 161
+[sst_expanded] 1
+[sst_vpaned_height] 264
+@28
+main_tb.clk
+main_tb.reset
+[color] 3
+main_tb.count_en
+@24
+main_tb.digit_1[3:0]
+@25
+main_tb.digit_10[3:0]
+@28
+main_tb.carry
+@24
+main_tb.carry_count[5:0]
+[pattern_trace] 1
+[pattern_trace] 0

--- a/upduino31/testbench/main_tb.v
+++ b/upduino31/testbench/main_tb.v
@@ -1,0 +1,115 @@
+// An example of an automated test. Run 'apio test' to test and 'apio sim' to examine
+// the wave signals.
+
+`timescale 10 ns / 1 ns
+
+`define DUMPSTR(x) `"x.vcd`"
+
+// A macro that check that given signal has given value. Normally it abors the simulation 
+// with an error, except when running with 'apio sim', in which case it prints an error
+// message and continues so we can examine the signal with gtkwave.
+`define EXPECT(signal, value) \
+    if (signal !== (value)) begin \
+        $display("ASSERTION FAILED in %m: signal != value  ('h%h)", (signal)); \
+        `ifndef INTERACTIVE_SIM \
+             $fatal; \
+        `endif \
+    end
+
+// A macro to wait for N clk positive edges, and then a little bit more for the last clock
+// to settle.
+`define CLK(n) \
+    begin \
+       repeat(n)  @ (posedge clk); \
+       #0.1; \
+    end
+
+// A macro to count N times.
+`define COUNT(n) \
+    begin \
+        `CLK(1) \
+        count_en = 1; \
+        `CLK(n) \
+        count_en = 0; \
+        `CLK(1) \
+    end
+
+
+module main_tb ();
+
+  always begin
+    #10 clk = ~clk;
+  end
+
+  // Inputs
+  reg clk = 0;
+  reg reset = 1;
+  reg count_en = 0;
+
+
+  // Outputs
+  wire [3:0] digit_1;
+  wire [3:0] digit_10;
+  wire carry;
+
+  // Counts the number of clocks with carry=1 so far.
+  reg [5:0] carry_count = 0;
+
+  always @(posedge clk) begin
+    carry_count <= reset ? 0 : carry ? carry_count + 1 : carry_count;
+  end
+
+  main main (
+      .clk(clk),
+      .reset(reset),
+      .count_en(count_en),
+      .digit_1(digit_1),
+      .digit_10(digit_10),
+      .carry
+  );
+
+  initial begin
+    $dumpfile(`DUMPSTR(`VCD_OUTPUT));
+    $dumpvars(0, main_tb);
+
+    // Test reset.
+    `CLK(3)
+    reset = 0;
+    `EXPECT(digit_10, 0) // count = 00
+    `EXPECT(digit_1, 0)
+    `EXPECT(carry_count, 0)
+
+    // Test transition from 09 to 10,
+    `CLK(3);
+    `COUNT(9)
+    `EXPECT(digit_10, 0)  // count = 09
+    `EXPECT(digit_1, 9)
+    `EXPECT(carry_count, 0)
+    `COUNT(1)
+    `EXPECT(digit_10, 1)  // count = 10
+    `EXPECT(digit_1, 0)
+    `EXPECT(carry_count, 0)
+
+    // Test transition from 99 to 00.
+    `COUNT(89)
+    `EXPECT(digit_10, 9) // count = 99
+    `EXPECT(digit_1, 9)
+    `EXPECT(carry_count, 0)
+    `COUNT(1)
+    `EXPECT(digit_10, 0) // count = 00
+    `EXPECT(digit_1, 0)
+    `EXPECT(carry_count, 1)
+
+    // Count a few more
+    `COUNT(12)
+    `EXPECT(digit_10, 1) // count = 12
+    `EXPECT(digit_1, 2)
+    `EXPECT(carry_count, 1)
+
+    // All done.
+    `CLK(10)
+    $display("End of simulation");
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
Last example before the release. Hope it's not too much burden.  ;-)

This example demonstrates how to write a testbench that will fail on assertion but but continues when running under 'apio sim' so we can see and diagnose the waves.