### PR TITLE
Removed the period at the end of the examples info description. 

### DIFF
--- a/examples/alhambra-ii/bcd-counter/info
+++ b/examples/alhambra-ii/bcd-counter/info
@@ -1,1 +1,1 @@
-A bcd counter with testbenches.
+A bcd counter with testbenches

--- a/examples/alhambra-ii/blinky/info
+++ b/examples/alhambra-ii/blinky/info
@@ -1,1 +1,1 @@
-Blinking led.
+Blinking led

--- a/examples/alhambra-ii/ledon/info
+++ b/examples/alhambra-ii/ledon/info
@@ -1,1 +1,1 @@
-Turning on a led.
+Turning on a led

--- a/examples/blackice/blink/info
+++ b/examples/blackice/blink/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/blackice/blinky/info
+++ b/examples/blackice/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/colorlight-5a-75b-v8/blinky/info
+++ b/examples/colorlight-5a-75b-v8/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/colorlight-5a-75b-v8/ledon/info
+++ b/examples/colorlight-5a-75b-v8/ledon/info
@@ -1,1 +1,1 @@
-Blinking leds.
+Blinking leds

--- a/examples/colorlight-5a-75e-v71-ft2232h/blinky/info
+++ b/examples/colorlight-5a-75e-v71-ft2232h/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/colorlight-5a-75e-v71-ft2232h/ledon/info
+++ b/examples/colorlight-5a-75e-v71-ft2232h/ledon/info
@@ -1,1 +1,1 @@
-Blinking leds.
+Blinking leds

--- a/examples/cynthion-r1-4/blinky/info
+++ b/examples/cynthion-r1-4/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/edu-ciaa-fpga/and-gate-sv/info
+++ b/examples/edu-ciaa-fpga/and-gate-sv/info
@@ -1,1 +1,1 @@
-Experimental system-verilog.
+Experimental system-verilog

--- a/examples/edu-ciaa-fpga/blinky/info
+++ b/examples/edu-ciaa-fpga/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/edu-ciaa-fpga/led-green/info
+++ b/examples/edu-ciaa-fpga/led-green/info
@@ -1,1 +1,1 @@
-Truning on a led.
+Truning on a led

--- a/examples/fomu/blink/info
+++ b/examples/fomu/blink/info
@@ -1,1 +1,1 @@
-Tri-colour led blink.
+Tri-colour led blink

--- a/examples/fomu/blinky/info
+++ b/examples/fomu/blinky/info
@@ -1,1 +1,1 @@
-Tri-colour led blink.
+Tri-colour led blink

--- a/examples/go-board/blinky/info
+++ b/examples/go-board/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/go-board/leds/info
+++ b/examples/go-board/leds/info
@@ -1,1 +1,1 @@
-Turning all leds on.
+Turning all leds on

--- a/examples/go-board/template/info
+++ b/examples/go-board/template/info
@@ -1,1 +1,1 @@
-Project template.
+Project template

--- a/examples/ice40-hx1k-evb/leds/info
+++ b/examples/ice40-hx1k-evb/leds/info
@@ -1,1 +1,1 @@
-Turning leds on/off.
+Turning leds on/off

--- a/examples/ice40-hx8k-evb/leds/info
+++ b/examples/ice40-hx8k-evb/leds/info
@@ -1,1 +1,1 @@
-Turning leds on/off.
+Turning leds on/off

--- a/examples/ice40-hx8k/leds/info
+++ b/examples/ice40-hx8k/leds/info
@@ -1,1 +1,1 @@
-Turning all the leds on.
+Turning all the leds on

--- a/examples/ice40-up5k/blinky/info
+++ b/examples/ice40-up5k/blinky/info
@@ -1,1 +1,1 @@
-Blink the RGB led.
+Blink the RGB led

--- a/examples/ice40-up5k/led-green/info
+++ b/examples/ice40-up5k/led-green/info
@@ -1,1 +1,1 @@
-Turning the RGB led green.
+Turning the RGB led green

--- a/examples/ice40-up5k/switches/info
+++ b/examples/ice40-up5k/switches/info
@@ -1,1 +1,1 @@
-Switches controlling RGB led.
+Switches controlling RGB led

--- a/examples/icebreaker/blinky/info
+++ b/examples/icebreaker/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/icebreaker/buttons/info
+++ b/examples/icebreaker/buttons/info
@@ -1,1 +1,1 @@
-Controlling a led using the buttons.
+Controlling a led using the buttons

--- a/examples/icebreaker/led-green/info
+++ b/examples/icebreaker/led-green/info
@@ -1,1 +1,1 @@
-Turning the green led on.
+Turning the green led on

--- a/examples/icestick/leds/info
+++ b/examples/icestick/leds/info
@@ -1,1 +1,1 @@
-Turning all the lds on.
+Turning all the lds on

--- a/examples/icestick/template/info
+++ b/examples/icestick/template/info
@@ -1,1 +1,1 @@
-Project template.
+Project template

--- a/examples/icesugar-1-5/blinky/info
+++ b/examples/icesugar-1-5/blinky/info
@@ -1,1 +1,1 @@
-Blinking red/green/blue leds.
+Blinking red/green/blue leds

--- a/examples/icewerx/ledon/info
+++ b/examples/icewerx/ledon/info
@@ -1,1 +1,1 @@
-Turning on the red led.
+Turning on the red led

--- a/examples/icezum/frere-jacques/info
+++ b/examples/icezum/frere-jacques/info
@@ -1,1 +1,1 @@
-Frère Jacques two voices melody (see README.md).
+Frère Jacques two voices melody (see READMEmd)

--- a/examples/icezum/template/info
+++ b/examples/icezum/template/info
@@ -1,1 +1,1 @@
-Project template.
+Project template

--- a/examples/icezum/wire/info
+++ b/examples/icezum/wire/info
@@ -1,1 +1,1 @@
-Describing a simple wire.
+Describing a simple wire

--- a/examples/kefir/leds/info
+++ b/examples/kefir/leds/info
@@ -1,1 +1,1 @@
-Turning all the leds on.
+Turning all the leds on

--- a/examples/kefir/template/info
+++ b/examples/kefir/template/info
@@ -1,1 +1,1 @@
-Project template.
+Project template

--- a/examples/sipeed-tang-nano-4k/blinky/info
+++ b/examples/sipeed-tang-nano-4k/blinky/info
@@ -1,1 +1,1 @@
-Blinking led (untested).
+Blinking led (untested)

--- a/examples/sipeed-tang-nano-9k/blinky/info
+++ b/examples/sipeed-tang-nano-9k/blinky/info
@@ -1,1 +1,1 @@
-Blinking led.
+Blinking led

--- a/examples/sipeed-tang-nano-9k/pll/info
+++ b/examples/sipeed-tang-nano-9k/pll/info
@@ -1,1 +1,1 @@
-PLL clock multiplier.
+PLL clock multiplier

--- a/examples/tinyfpga-b2/blinky/info
+++ b/examples/tinyfpga-b2/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/tinyfpga-bx/blink-sos/info
+++ b/examples/tinyfpga-bx/blink-sos/info
@@ -1,1 +1,1 @@
-Blink SOS pattern.
+Blink SOS pattern

--- a/examples/tinyfpga-bx/blinky/info
+++ b/examples/tinyfpga-bx/blinky/info
@@ -1,1 +1,1 @@
-Blinking led.
+Blinking led

--- a/examples/tinyfpga-bx/clock-divider/info
+++ b/examples/tinyfpga-bx/clock-divider/info
@@ -1,1 +1,1 @@
-Clock divider with two phases outputs.
+Clock divider with two phases outputs

--- a/examples/tinyfpga-bx/template/info
+++ b/examples/tinyfpga-bx/template/info
@@ -1,1 +1,1 @@
-Project template.
+Project template

--- a/examples/ulx3s-12f/blinky/info
+++ b/examples/ulx3s-12f/blinky/info
@@ -1,1 +1,1 @@
-Blinking a led.
+Blinking a led

--- a/examples/ulx3s-12f/ledon/info
+++ b/examples/ulx3s-12f/ledon/info
@@ -1,1 +1,1 @@
-Turning on a led.
+Turning on a led

--- a/examples/ulx3s-45f/blinky/info
+++ b/examples/ulx3s-45f/blinky/info
@@ -1,1 +1,1 @@
-Blinking leds.
+Blinking leds

--- a/examples/ulx3s-85f/blinky/info
+++ b/examples/ulx3s-85f/blinky/info
@@ -1,1 +1,1 @@
-Blinking leds.
+Blinking leds

--- a/examples/upduino31/blinky/info
+++ b/examples/upduino31/blinky/info
@@ -1,1 +1,1 @@
-Using the SB_RGBA_DRV primitive led driver.
+Using the SB_RGBA_DRV primitive led driver

--- a/examples/upduino31/pll/info
+++ b/examples/upduino31/pll/info
@@ -1,1 +1,1 @@
-Generating 30Mhz clock using a pll.
+Generating 30Mhz clock using a pll

--- a/examples/upduino31/testbench/info
+++ b/examples/upduino31/testbench/info
@@ -1,1 +1,1 @@
-A testbench example.
+A testbench example


### PR DESCRIPTION
It looks better this way in the apio examples report.