### PR TITLE
Reduced the idle rate of the build and release workflow from 1 day to one month.

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -4,9 +4,9 @@ on:
   # Run on each commit to this repo.
   push:
 
-  # Run daily at 10AM UTC
+  # Run monthly on the 1st, 10AM UTC
   schedule:
-    - cron: "0 10 * * *"
+    - cron: "0 10 1 * *"
 
   # Allow manual activations.
   workflow_dispatch:


### PR DESCRIPTION
It still builds and release on each push.